### PR TITLE
Add multi-tenant RAG API for real estate teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,36 @@
-# CrewAI + Ollama + DuckDuckGo (no API keys)
+# Real Estate RAG API
 
-Local agents using CrewAI + a custom DuckDuckGo tool and an Ollama model.
+A multi-tenant Retrieval Augmented Generation API for real estate teams. Each
+client can ingest their own documents (policies, listings, HOA/MLS rules) and
+ask grounded questions that return concise answers with citations.
+
+## Features
+- Ingestion via JSON or file upload (pdf/txt/md) with automatic chunking.
+- Per-tenant TF‑IDF indexing on disk under `data/processed/{client_id}`.
+- Deterministic dummy LLM for local development and tests (no API key required).
+- Optional local [Transformers](https://huggingface.co/docs/transformers/index)
+  model when `RAG_MODEL_NAME` is set (e.g., `google/flan-t5-small`).
+- REST endpoints:
+  - `GET /healthz`
+  - `POST /v1/ingest-json`
+  - `POST /v1/ingest-files`
+  - `POST /v1/ask`
 
 ## Quickstart
 ```bash
 python -m venv .venv && source .venv/bin/activate
-python -m pip install -U pip
 pip install -r requirements.txt
+python main.py  # starts the API on :8000
+```
 
-# start Ollama in another terminal
-ollama serve
-ollama pull openhermes
+To use a local Transformers model:
 
-python flow.py
+```bash
+pip install transformers torch  # run once
+RAG_MODEL_NAME=google/flan-t5-small python main.py
+```
+
+## Running Tests
+```bash
+pytest
+```

--- a/rag/llm.py
+++ b/rag/llm.py
@@ -1,0 +1,29 @@
+import os
+from typing import Any, Optional
+
+
+class LLM:
+    """LLM wrapper that uses a dummy model unless a transformers model is specified."""
+
+    def __init__(self) -> None:
+        self.model_name = os.getenv("RAG_MODEL_NAME")
+        self.pipeline: Optional[Any] = None
+        if self.model_name:
+            try:
+                from transformers import pipeline  # type: ignore
+            except Exception as exc:  # pragma: no cover - import error path
+                raise RuntimeError(
+                    "transformers package is required when RAG_MODEL_NAME is set"
+                ) from exc
+            self.pipeline = pipeline("text2text-generation", model=self.model_name)
+
+    def generate(self, question: str, context: str) -> str:
+        if self.pipeline:
+            prompt = (
+                "Answer the question using only the provided context.\n"
+                f"Context:\n{context}\n\nQuestion: {question}"
+            )
+            result = self.pipeline(prompt, max_new_tokens=128)[0]["generated_text"]
+            return result.strip()
+        # Deterministic dummy response for tests/dev
+        return f"Answer: {context.strip()}"

--- a/rag/storage.py
+++ b/rag/storage.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List
+import json
+
+import joblib
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import linear_kernel
+
+DATA_DIR = Path("data/processed")
+
+
+def _client_dir(client_id: str) -> Path:
+    path = DATA_DIR / client_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _chunk_text(text: str, size: int = 500, overlap: int = 50) -> List[str]:
+    chunks: List[str] = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + size)
+        chunks.append(text[start:end])
+        start += size - overlap
+    return chunks
+
+
+def ingest_docs(client_id: str, docs: Iterable[Dict[str, str]]) -> None:
+    """Ingest a collection of documents for a client."""
+    client_path = _client_dir(client_id)
+    all_chunks: List[Dict[str, str]] = []
+    for doc in docs:
+        text = doc["text"]
+        doc_id = doc["id"]
+        for i, chunk in enumerate(_chunk_text(text)):
+            all_chunks.append({"id": f"{doc_id}_{i}", "text": chunk})
+    texts = [c["text"] for c in all_chunks]
+    vectorizer = TfidfVectorizer()
+    matrix = vectorizer.fit_transform(texts)
+    joblib.dump({"vectorizer": vectorizer, "matrix": matrix, "chunks": all_chunks}, client_path / "index.joblib")
+    # store original docs for reference
+    with open(client_path / "docs.json", "w", encoding="utf-8") as f:
+        json.dump(list(docs), f)
+
+
+def ingest_files(client_id: str, files: Iterable[Path]) -> None:
+    docs: List[Dict[str, str]] = []
+    for path in files:
+        suffix = path.suffix.lower()
+        if suffix == ".pdf":
+            try:
+                from pypdf import PdfReader  # type: ignore
+            except Exception as exc:
+                raise RuntimeError("pypdf is required for PDF ingestion") from exc
+            reader = PdfReader(str(path))
+            text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        else:
+            text = path.read_text(encoding="utf-8")
+        docs.append({"id": path.stem, "text": text})
+    ingest_docs(client_id, docs)
+
+
+def query_index(client_id: str, question: str, top_k: int = 3) -> List[Dict[str, str]]:
+    client_path = _client_dir(client_id)
+    index_file = client_path / "index.joblib"
+    if not index_file.exists():
+        raise FileNotFoundError(f"No index found for client {client_id}")
+    data = joblib.load(index_file)
+    vectorizer: TfidfVectorizer = data["vectorizer"]
+    matrix = data["matrix"]
+    chunks: List[Dict[str, str]] = data["chunks"]
+    q_vec = vectorizer.transform([question])
+    sims = linear_kernel(q_vec, matrix).flatten()
+    top_indices = sims.argsort()[::-1][:top_k]
+    return [chunks[i] for i in top_indices]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+scikit-learn
+joblib
+pydantic
+pytest
+httpx
+python-multipart
+pypdf

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,35 @@
+import shutil
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# ensure root directory on path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from main import app
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    shutil.rmtree(Path("data"), ignore_errors=True)
+
+
+def test_ingest_and_ask() -> None:
+    payload = {
+        "client_id": "tenant1",
+        "docs": [
+            {"id": "policy", "text": "Pets are not allowed in the building."},
+            {"id": "fees", "text": "The HOA fee is $100."},
+        ],
+    }
+    r = client.post("/v1/ingest-json", json=payload)
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+    r = client.post("/v1/ask", json={"client_id": "tenant1", "question": "Are pets allowed?"})
+    data = r.json()
+    assert "answer" in data
+    assert "Pets are not allowed" in data["answer"]
+    assert data["citations"]
+    assert any("policy" in c["id"] for c in data["citations"])


### PR DESCRIPTION
- Implement FastAPI-based multi-tenant RAG service with ingestion and query endpoints
- Add deterministic dummy LLM with optional local Transformers model (no API key required)
- Provide pytest coverage for ingestion and question-answer flow

## Testing
- `pip install -r requirements.txt`
- `pytest`
